### PR TITLE
Problem with incompatible pointer types

### DIFF
--- a/include/libxml/debugXML.h
+++ b/include/libxml/debugXML.h
@@ -100,7 +100,7 @@ XMLPUBFUN const char *
  *
  * Returns a string which will be freed by the Shell.
  */
-typedef char * (* xmlShellReadlineFunc)(char *prompt);
+typedef char * (* xmlShellReadlineFunc)(const char *prompt);
 
 /**
  * xmlShellCtxt:


### PR DESCRIPTION
```
xmllint.c: In function 'parseAndPrintFile':
xmllint.c:2465:33: warning: passing argument 3 of 'xmlShell' from incompatible pointer type [-Wincompatible-pointer-types]
 2465 |         xmlShell(doc, filename, xmlShellReadline, stdout);
      |                                 ^~~~~~~~~~~~~~~~
      |                                 |
      |                                 char * (*)(const char *)
In file included from xmllint.c:56:
debugXML.h:207:55: note: expected 'xmlShellReadlineFunc' {aka 'char * (*)(char *)'} but argument is of type 'char * (*)(const char *)'
  207 |                                  xmlShellReadlineFunc input,
      |                                  ~~~~~~~~~~~~~~~~~~~~~^~~~~
```